### PR TITLE
fix: correct class name in documentation and export IncludeClass

### DIFF
--- a/lib/contentstack.dart
+++ b/lib/contentstack.dart
@@ -15,3 +15,5 @@ export 'src/models/entrymodel.dart';
 export 'src/models/syncresult.dart';
 export 'src/query.dart';
 export 'src/stack.dart';
+export 'src/enums/include.dart';
+export 'src/enums/include_type.dart';


### PR DESCRIPTION
- Exported `IncludeClass` and `IncludeType` to make them accessible as per the [IncludeReference documentation]()https://www.contentstack.com/docs/developers/sdks/content-delivery-sdk/dart/reference#entry-includereference).